### PR TITLE
gralloc_gbm: Quiet logcat verbosity

### DIFF
--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -420,7 +420,7 @@ int gralloc_gbm_bo_lock(buffer_handle_t handle,
 		gbm_bo_set_user_data(bo, bo_data, gralloc_gbm_destroy_user_data);
 	}
 
-	ALOGI("lock bo %p, cnt=%d, usage=%x", bo, bo_data->lock_count, usage);
+	ALOGV("lock bo %p, cnt=%d, usage=%x", bo, bo_data->lock_count, usage);
 
 	/* allow multiple locks with compatible usages */
 	if (bo_data->lock_count && (bo_data->locked_for & usage) != usage)
@@ -494,7 +494,7 @@ int gralloc_gbm_bo_lock_ycbcr(buffer_handle_t handle,
 	void *addr = 0;
 	int err;
 
-	ALOGD("handle %p, hnd %p, usage 0x%x", handle, hnd, usage);
+	ALOGV("handle %p, hnd %p, usage 0x%x", handle, hnd, usage);
 
 	err = gralloc_gbm_bo_lock(handle, usage, x, y, w, h, &addr);
 	if (err)


### PR DESCRIPTION
When using gralloc_gbm, especially playing yuv video, there's tons
of log noise like:

09-17 05:46:12.823   494  2001 D GRALLOC-GBM: handle 0xb400006d6a4d4380, hnd 0xb400006d6a4d4380, usage 0x33
09-17 05:46:12.824   494  2001 I GRALLOC-GBM: lock bo 0xb400006d7a4a26f0, cnt=0, usage=33

over and over.

So set these two messages to verbose via ALOGV.

Signed-off-by: John Stultz <john.stultz@linaro.org>